### PR TITLE
Compatibility with python 3.8

### DIFF
--- a/pygem/massbalance.py
+++ b/pygem/massbalance.py
@@ -209,13 +209,19 @@ class PyGEMMassBalance(MassBalanceModel):
         glacier_area_initial = self.glacier_area_initial
         fl_widths_m = getattr(fl, 'widths_m', None)
         fl_section = getattr(fl,'section',None)
+
         # Ice thickness (average)
         if fl_section is not None and fl_widths_m is not None:
             icethickness_t0 = np.zeros(fl_section.shape)
             icethickness_t0[fl_widths_m > 0] = fl_section[fl_widths_m > 0] / fl_widths_m[fl_widths_m > 0]
         else:
             icethickness_t0 = None
-
+        print('******************** attributes of the flowline at the time t0 ******************** ')
+        print('glacier_area_initial is:',glacier_area_initial)
+        print('glacier_area_t0 is:',glacier_area_t0)
+        print('the fl_widths_m at t0 is:',fl_widths_m)
+        print('the fl_section area at t0 is:',fl_section)
+        print('the ice thickness at t0 is:',icethickness_t0)
         # Quality control: ensure you only have glacier area where there is ice
         if icethickness_t0 is not None:
             glacier_area_t0[icethickness_t0 == 0] = 0

--- a/pygem/pygem_modelsetup.py
+++ b/pygem/pygem_modelsetup.py
@@ -56,7 +56,7 @@ def datesmodelrun(startyear=pygem_prms.ref_startyear, endyear=pygem_prms.ref_end
     if pygem_prms.timestep == 'monthly':
         # Automatically generate dates from start date to end data using a monthly frequency (MS), which generates
         # monthly data using the 1st of each month'
-        dates_table = pd.DataFrame({'date' : pd.date_range(startdate, enddate, freq='MS', unit='s')})
+        dates_table = pd.DataFrame({'date' : pd.date_range(startdate, enddate, freq='MS')})
         # Select attributes of DateTimeIndex (dt.year, dt.month, and dt.daysinmonth)
         dates_table['year'] = dates_table['date'].dt.year
         dates_table['month'] = dates_table['date'].dt.month


### PR DESCRIPTION
Since in the docs it says to use `pymc2` and python3.8.18, the version of pandas that will make oggm to pass tests has to be <2. Some pandas functions, like `date_range` will not have arguments that are present in the code. Otherwise new pymc should be checked out, so newer version of pandas and xarray can be loaded.