### PR TITLE
Update oggm dependency version in pyproject.toml

### DIFF
--- a/pygem/bin/postproc/__init__.py
+++ b/pygem/bin/postproc/__init__.py
@@ -1,0 +1,7 @@
+"""
+Python Glacier Evolution Model (PyGEM)
+
+copyright © 2018 David Rounce <drounce@cmu.edu
+
+Distributed under the MIT license
+"""

--- a/pygem/setup/__init__.py
+++ b/pygem/setup/__init__.py
@@ -5,4 +5,3 @@ copyright © 2018 David Rounce <drounce@cmu.edu>
 
 Distributed under the MIT license
 """
-

--- a/pygem/setup/__init__.py
+++ b/pygem/setup/__init__.py
@@ -5,3 +5,4 @@ copyright © 2018 David Rounce <drounce@cmu.edu>
 
 Distributed under the MIT license
 """
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ scikit-learn = "^1.5.2"
 tqdm = "^4.66.6"
 jupyter = "^1.1.1"
 arviz = "^0.20.0"
-oggm = { git = "https://github.com/OGGM/oggm.git"}
+oggm = "^1.6.3"
 ruamel-yaml = "^0.18.10"
 ruff = ">=0.9.6"
 pytest = ">=8.3.4"


### PR DESCRIPTION
OGGM created a new release in April 2026 (v1.6.3) which includes the `allow_calving` key-word argument in their `run_dynamic_spinup()` method, so OGGM can now be sourced directly from PyPI once again and a PyGEM v1.1.0 can likely be released.